### PR TITLE
The optimizer should optimize the query when using GlobalID

### DIFF
--- a/graphene_django_optimizer/__init__.py
+++ b/graphene_django_optimizer/__init__.py
@@ -1,3 +1,3 @@
 from .field import field  # noqa: F401
-from .query import query  # noqa: F401
+from .query import query, QueryOptimizer  # noqa: F401
 from .resolver import resolver_hints  # noqa: F401

--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -343,10 +343,10 @@ class QueryOptimizerStore():
         self.only_list = None
 
     def optimize_queryset(self, queryset):
-        if self.select_related:
+        if self.select_list:
             queryset = queryset.select_related(*self.select_list)
 
-        if self.prefetch_related:
+        if self.prefetch_list:
             queryset = queryset.prefetch_related(*self.prefetch_list)
 
         if self.only_list:

--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -262,7 +262,7 @@ class QueryOptimizer(object):
                 # function for safety.
                 # if resolver_fn.args:
                 #     return resolver_fn.args[0] == resolve_id
-                
+
                 if resolver_fn.args:
                     return resolver_fn.args[0].__name__ == 'resolve_id'
 

--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -343,8 +343,12 @@ class QueryOptimizerStore():
         self.only_list = None
 
     def optimize_queryset(self, queryset):
-        queryset = queryset.select_related(*self.select_list)
-        queryset = queryset.prefetch_related(*self.prefetch_list)
+        if self.select_related:
+            queryset = queryset.select_related(*self.select_list)
+
+        if self.prefetch_related:
+            queryset = queryset.prefetch_related(*self.prefetch_list)
+
         if self.only_list:
             queryset = queryset.only(*self.only_list)
         return queryset

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,10 @@
+import uuid
+
 from django.db import models
 
 
 class Item(models.Model):
+    uuid = models.UUIDField(default=uuid.uuid4)
     name = models.CharField(max_length=100, blank=True)
     parent = models.ForeignKey('Item', on_delete=models.SET_NULL, null=True, related_name='children')
     item = models.ForeignKey('Item', on_delete=models.SET_NULL, null=True)

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -8,6 +8,7 @@ from .models import (
 )
 from .schema import schema
 from .test_utils import assert_query_equality
+from .test_utils import assert_num_queries
 
 
 @pytest.mark.django_db
@@ -233,19 +234,20 @@ def test_should_optimize_query_when_using_global_uuid():
 def test_verify_should_return_global_uuid():
     Item.objects.create(id=9, uuid='8ea0da0b-da77-4b11-8fbb-350f59a41854', name='bar')
 
-    # UUID should be used as a global id.
-    result = schema.execute('''
-        query {
-            relayItemsGlobalUuid {
-                edges {
-                    node {
-                        id,
-                        name
+    with assert_num_queries(2):
+        # UUID should be used as a global id.
+        result = schema.execute('''
+            query {
+                relayItemsGlobalUuid {
+                    edges {
+                        node {
+                            id,
+                            name
+                        }
                     }
                 }
             }
-        }
-    ''')
+        ''')
 
     # ItemNodeGlobalUUID:8ea0da0b-da77-4b11-8fbb-350f59a41854
     expected_id = 'SXRlbU5vZGVHbG9iYWxVVUlEOjhlYTBkYTBiLWRhNzctNGIxMS04ZmJiLTM1MGY1OWE0MTg1NA=='

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,10 +26,10 @@ class _AssertNumQueriesContext(CaptureQueriesContext):
 
     def __init__(self, num, connection):
         self.num = num
-        super().__init__(connection)
+        super(self, _AssertNumQueriesContext).__init__(connection)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        super().__exit__(exc_type, exc_value, traceback)
+        super(self, _AssertNumQueriesContext).__exit__(exc_type, exc_value, traceback)
         if exc_type is not None:
             return
         executed = len(self)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,10 +26,10 @@ class _AssertNumQueriesContext(CaptureQueriesContext):
 
     def __init__(self, num, connection):
         self.num = num
-        super(self, _AssertNumQueriesContext).__init__(connection)
+        super(_AssertNumQueriesContext, self).__init__(connection)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        super(self, _AssertNumQueriesContext).__exit__(exc_type, exc_value, traceback)
+        super(_AssertNumQueriesContext, self).__exit__(exc_type, exc_value, traceback)
         if exc_type is not None:
             return
         executed = len(self)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
+from django.db import connections, DEFAULT_DB_ALIAS
 from django.db.models import Prefetch
+from django.test.utils import CaptureQueriesContext
 
 
 def assert_query_equality(left_query, right_query):
@@ -14,3 +16,42 @@ def assert_query_equality(left_query, right_query):
             assert lookup == str(right_lookup.queryset.query)
         else:
             assert lookup == right_lookup
+
+
+class _AssertNumQueriesContext(CaptureQueriesContext):
+    """
+        Adapted from
+        https://docs.djangoproject.com/en/2.1/_modules/django/test/testcases/#_AssertNumQueriesContext
+    """
+
+    def __init__(self, num, connection):
+        self.num = num
+        super().__init__(connection)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if exc_type is not None:
+            return
+        executed = len(self)
+
+        assert executed == self.num, "%d queries executed, %d expected\nCaptured queries were:\n%s" % (
+            executed, self.num,
+            '\n'.join(
+                '%d. %s' % (i, query['sql']) for i, query in enumerate(self.captured_queries, start=1)
+            )
+        )
+
+
+def assert_num_queries(num, func=None, *args, **kwargs):
+    """
+        Adapted from
+        https://docs.djangoproject.com/en/2.1/_modules/django/test/testcases/#TransactionTestCase.assertNumQueries
+    """
+    conn = connections[DEFAULT_DB_ALIAS]
+
+    context = _AssertNumQueriesContext(num, conn)
+    if func is None:
+        return context
+
+    with context:
+        func(*args, **kwargs)


### PR DESCRIPTION
**The optimizer should optimize the query when using GlobalID from Relay.**

The current behavior is to jump to `abort_only_optimization` because the ID resolver is a partial function from `GlobalID.id_resolver` instead of the expected `DjangoObjectType.resolve_id`. Changed the behavior to also allow for GlobalID.

**The optimizer should defer the correct fields when using a CustomID with `resolve_id`**

When using a custom id (for instance an uuid) from `resolve_id` the query would be optimized with incorrect `only` fields since `id` was hardcoded. Changed the behavior of `QueryOptimizer` to allow for a custom `id_field` in the constructor. Also added an export for `QueryOptimizer` to allow `query` to remain simple.

Added tests for both scenarios.

**When passed an empty select_related list, a queryset will select all related fields**

https://github.com/django/django/blob/2.1.3/django/db/models/query.py#L949

Added a condition for select_related and prefetch_related