### PR TITLE
Add option to disable the abort_only_optimization method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,28 @@ class CartType(DjangoObjectType):
 ```
 
 With these hints, any field can be optimized.
+
+
+### Optimize with non model fields
+
+Sometimes we need to have a custom non model fields. In those cases, the optimizer would not optimize with the Django `.only()` method.
+So if we still want to optimize with the `.only()` method, we need to use `disable_abort_only` option:
+
+```py
+
+class IngredientType(DjangoObjectType):
+    calculated_calories = graphene.String()
+
+    class Meta:
+        model = Ingredient
+    
+    def resolve_calculated_calories(root, info):
+        return get_calories_for_ingredient(root.id)
+
+
+class Query(object):
+    all_ingredients = graphene.List(IngredientType)
+
+    def resolve_all_ingredients(root, info):
+        return gql_optimizer.query(Ingredient.objects.all(), info, disable_abort_only=True)
+```

--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -23,13 +23,29 @@ from graphql.type.definition import (
 from .utils import is_iterable
 
 
-def query(queryset, info):
-    return QueryOptimizer(info).optimize(queryset)
+def query(queryset, info, **options):
+    """
+    Automatically optimize queries.
+
+    Arguments:
+        - queryset (Django QuerySet object) - The queryset to be optimized
+        - info (GraphQL ResolveInfo object) - This is passed by the graphene-django resolve methods
+        - **options - optimization options/settings
+            - disable_abort_only (boolean) - in case the objecttype contains any extra fields,
+                                             then this will keep the "only" optimization enabled.
+    """
+
+    return QueryOptimizer(info, **options).optimize(queryset)
 
 
 class QueryOptimizer(object):
-    def __init__(self, info):
+    """
+    Automatically optimize queries.
+    """
+
+    def __init__(self, info, **options):
         self.root_info = info
+        self.disable_abort_only = options.pop('disable_abort_only', False)
 
     def optimize(self, queryset):
         info = self.root_info
@@ -93,7 +109,10 @@ class QueryOptimizer(object):
         store.append(fragment_store)
 
     def _optimize_gql_selections(self, field_type, field_ast):
-        store = QueryOptimizerStore()
+        store = QueryOptimizerStore(
+            disable_abort_only=self.disable_abort_only,
+        )
+
         selection_set = field_ast.selection_set
         if not selection_set:
             return store
@@ -285,10 +304,11 @@ class QueryOptimizer(object):
 
 
 class QueryOptimizerStore():
-    def __init__(self):
+    def __init__(self, disable_abort_only=False):
         self.select_list = []
         self.prefetch_list = []
         self.only_list = []
+        self.disable_abort_only = disable_abort_only
 
     def select_related(self, name, store):
         if store.select_list:
@@ -328,7 +348,8 @@ class QueryOptimizerStore():
             self.only_list.append(field)
 
     def abort_only_optimization(self):
-        self.only_list = None
+        if not self.disable_abort_only:
+            self.only_list = None
 
     def optimize_queryset(self, queryset):
         queryset = queryset.select_related(*self.select_list)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -123,6 +123,22 @@ def test_should_not_try_to_optimize_non_field_model_fields():
     assert_query_equality(items, optimized_items)
 
 
+def test_should_try_to_optimize_non_field_model_fields_when_disabling_abort_only():
+    # Item.objects.create(name='foo')
+    info = create_resolve_info(schema, '''
+        query {
+            items(name: "foo") {
+                id
+                unoptimizedTitle
+            }
+        }
+    ''')
+    qs = Item.objects.filter(name='foo')
+    items = gql_optimizer.query(qs, info, disable_abort_only=True)
+    optimized_items = qs.only('id')
+    assert_query_equality(items, optimized_items)
+
+
 # @pytest.mark.django_db
 def test_should_optimize_when_using_fragments():
     # parent = Item.objects.create(name='foo')


### PR DESCRIPTION
I read issue #2 after stumbling upon that issue myself. last comment was a suggestion to add that as an option. This PR implements an options solution with `disable_abort_only`  as it's first option.

### This PR includes:
- Added documentation to code.
- Added options argument.
- Added `disable_abort_only` argument to options.
- Added test coverage.
- Added info to readme.

About the readme changes - I don't know if this is something you would want, but I thought it's good to have. However, I don't know the reason why not to call the `.only` method. so it might be good to add some explanations on why this behaviour is there. I am also curious 😄 