### PR TITLE
Add a type to retrieve single nodes with optimizations made

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 build/
 .coverage
 htmlcov/
+.*/

--- a/README.md
+++ b/README.md
@@ -115,11 +115,10 @@ If the resolver returns a model field, we can use the `model_field` argument:
 
 ```py
 import graphene
-from graphene_django.types import DjangoObjectType
 import graphene_django_optimizer as gql_optimizer
 
 
-class ItemType(DjangoObjectType):
+class ItemType(gql_optimizer.OptimizedDjangoObjectType):
     product = graphene.Field('ProductType')
 
     @gql_optimizer.resolver_hints(
@@ -138,11 +137,10 @@ Now, if the resolver uses related fields, you can use the `select_related` argum
 
 ```py
 import graphene
-from graphene_django.types import DjangoObjectType
 import graphene_django_optimizer as gql_optimizer
 
 
-class ItemType(DjangoObjectType):
+class ItemType(gql_optimizer.OptimizedDjangoObjectType):
     name = graphene.String()
 
     @gql_optimizer.resolver_hints(
@@ -153,6 +151,9 @@ class ItemType(DjangoObjectType):
         return '{} {}'.format(root.product.name, root.shipping.name)
 ```
 
+Notice the usage of the type `OptimizedDjangoObjectType`, which enables
+optimization of any single node queries.
+
 Finally, if your field has an argument for filtering results,
 you can use the `prefetch_related` argument with a function
 that returns a `Prefetch` instance as the value.
@@ -160,11 +161,10 @@ that returns a `Prefetch` instance as the value.
 ```py
 from django.db.models import Prefetch
 import graphene
-from graphene_django.types import DjangoObjectType
 import graphene_django_optimizer as gql_optimizer
 
 
-class CartType(DjangoObjectType):
+class CartType(gql_optimizer.OptimizedDjangoObjectType):
     items = graphene.List(
         'ItemType',
         product_id=graphene.ID(),
@@ -191,7 +191,7 @@ So if we still want to optimize with the `.only()` method, we need to use `disab
 
 ```py
 
-class IngredientType(DjangoObjectType):
+class IngredientType(gql_optimizer.OptimizedDjangoObjectType):
     calculated_calories = graphene.String()
 
     class Meta:

--- a/dev-env-requirements.txt
+++ b/dev-env-requirements.txt
@@ -5,3 +5,4 @@ pytest==4.4.1
 pytest-django==3.4.8
 pytest-cov==2.6.1
 flake8==3.7.7
+mock==2.0.0

--- a/graphene_django_optimizer/__init__.py
+++ b/graphene_django_optimizer/__init__.py
@@ -1,3 +1,4 @@
 from .field import field  # noqa: F401
 from .query import query  # noqa: F401
 from .resolver import resolver_hints  # noqa: F401
+from .types import OptimizedDjangoObjectType  # noqa: F401

--- a/graphene_django_optimizer/types.py
+++ b/graphene_django_optimizer/types.py
@@ -1,0 +1,18 @@
+from graphene_django.types import DjangoObjectType
+from .query import query
+
+
+class OptimizedDjangoObjectType(DjangoObjectType):
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def optimize_node(cls, info, qs, pk):
+        try:
+            return query(qs, info).get(pk=pk)
+        except cls._meta.model.DoesNotExist:
+            return None
+
+    @classmethod
+    def get_node(cls, info, id):
+        return cls.optimize_node(info, cls._meta.model.objects, id)

--- a/graphene_django_optimizer/types.py
+++ b/graphene_django_optimizer/types.py
@@ -29,4 +29,15 @@ class OptimizedDjangoObjectType(DjangoObjectType):
 
     @classmethod
     def get_node(cls, info, id):
+        """
+        Bear in mind that if you are overriding this method get_node(info, pk),
+        you should always call maybe_optimize(info, qs, pk)
+        and never directly call get_optimized_node(info, qs, pk) as it would
+        result to the node being attempted to be optimized when it is not
+        supposed to actually get optimized.
+
+        :param info:
+        :param id:
+        :return:
+        """
         return cls.maybe_optimize(info, cls._meta.model.objects, id)

--- a/graphene_django_optimizer/types.py
+++ b/graphene_django_optimizer/types.py
@@ -7,7 +7,7 @@ class OptimizedDjangoObjectType(DjangoObjectType):
         abstract = True
 
     @classmethod
-    def optimize_node(cls, info, qs, pk):
+    def get_optimized_node(cls, info, qs, pk):
         try:
             return query(qs, info).get(pk=pk)
         except cls._meta.model.DoesNotExist:
@@ -15,4 +15,4 @@ class OptimizedDjangoObjectType(DjangoObjectType):
 
     @classmethod
     def get_node(cls, info, id):
-        return cls.optimize_node(info, cls._meta.model.objects, id)
+        return cls.get_optimized_node(info, cls._meta.model.objects, id)

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -1,8 +1,8 @@
 from django.db.models import Prefetch
 import graphene
 from graphene_django.fields import DjangoConnectionField
-from graphene_django.types import DjangoObjectType
 import graphene_django_optimizer as gql_optimizer
+from graphene_django_optimizer import OptimizedDjangoObjectType
 
 from .models import (
     DetailedItem,
@@ -58,7 +58,7 @@ class ItemInterface(graphene.Interface):
         return getattr(root, 'gql_filtered_children_' + name)
 
 
-class BaseItemType(DjangoObjectType):
+class BaseItemType(OptimizedDjangoObjectType):
     title = gql_optimizer.field(
         graphene.String(),
         only='name',
@@ -85,12 +85,12 @@ class ItemNode(BaseItemType):
         interfaces = (graphene.relay.Node, ItemInterface, )
 
 
-class SomeOtherItemType(DjangoObjectType):
+class SomeOtherItemType(OptimizedDjangoObjectType):
     class Meta:
         model = SomeOtherItem
 
 
-class OtherItemType(DjangoObjectType):
+class OtherItemType(OptimizedDjangoObjectType):
     class Meta:
         model = OtherItem
 
@@ -123,12 +123,12 @@ class ExtraDetailedItemType(DetailedItemType):
         interfaces = (ItemInterface, )
 
 
-class RelatedOneToManyItemType(DjangoObjectType):
+class RelatedOneToManyItemType(OptimizedDjangoObjectType):
     class Meta:
         model = RelatedOneToManyItem
 
 
-class UnrelatedModelType(DjangoObjectType):
+class UnrelatedModelType(OptimizedDjangoObjectType):
     class Meta:
         model = UnrelatedModel
         interfaces = (DetailedInterface, )

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -136,7 +136,7 @@ class UnrelatedModelType(OptimizedDjangoObjectType):
 
 class DummyItemMutation(graphene.Mutation):
     item = graphene.Field(
-        ItemType, description='The retrieved item.', required=False)
+        ItemNode, description='The retrieved item.', required=False)
 
     class Arguments:
         item_id = graphene.ID(description='The ID of the item.')
@@ -147,7 +147,7 @@ class DummyItemMutation(graphene.Mutation):
     @staticmethod
     def mutate(info, item_id):
         return graphene.Node.get_node_from_global_id(
-            info, item_id, only_type=ItemType)
+            info, item_id, only_type=ItemNode)
 
 
 class Query(graphene.ObjectType):

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -134,10 +134,27 @@ class UnrelatedModelType(OptimizedDjangoObjectType):
         interfaces = (DetailedInterface, )
 
 
+class DummyItemMutation(graphene.Mutation):
+    item = graphene.Field(
+        ItemType, description='The retrieved item.', required=False)
+
+    class Arguments:
+        item_id = graphene.ID(description='The ID of the item.')
+
+    class Meta:
+        description = 'A dummy mutation that retrieves a given item node.'
+
+    @staticmethod
+    def mutate(info, item_id):
+        return graphene.Node.get_node_from_global_id(
+            info, item_id, only_type=ItemType)
+
+
 class Query(graphene.ObjectType):
     items = graphene.List(ItemInterface, name=graphene.String(required=True))
     relay_items = DjangoConnectionField(ItemNode)
     other_items = graphene.List(OtherItemType)
+    some_other_items = graphene.List(SomeOtherItemType)
 
     def resolve_items(root, info, name):
         return gql_optimizer.query(Item.objects.filter(name=name), info)
@@ -149,4 +166,5 @@ class Query(graphene.ObjectType):
         return gql_optimizer.query(OtherItemType.objects.all(), info)
 
 
-schema = graphene.Schema(query=Query, types=(UnrelatedModelType, ))
+schema = graphene.Schema(
+    query=Query, types=(UnrelatedModelType, ), mutation=DummyItemMutation)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2,20 +2,19 @@ import pytest
 from mock import patch
 
 from .graphql_utils import create_resolve_info
-from .models import (
-    Item,
-)
-from .schema import schema, ItemType
+from .models import SomeOtherItem
+from .schema import schema, SomeOtherItemType, DummyItemMutation
 
 
 @pytest.mark.django_db
-@patch('graphene_django_optimizer.types.query', return_value=Item.objects)
+@patch('graphene_django_optimizer.types.query',
+       return_value=SomeOtherItem.objects)
 def test_should_optimize_the_single_node(mocked_optimizer):
-    Item.objects.create(id=7)
+    SomeOtherItem.objects.create(pk=7, name='Hello')
 
     info = create_resolve_info(schema, '''
         query ItemDetails {
-            items(id: $id) {
+            someOtherItems(id: $id) {
                 id
                 foo
                 parent {
@@ -25,18 +24,43 @@ def test_should_optimize_the_single_node(mocked_optimizer):
         }
     ''')
 
-    result = ItemType.get_node(info, 7)
+    info.return_type = schema.get_type('SomeOtherItemType')
+    result = SomeOtherItemType.get_node(info, 7)
 
     assert result, 'Expected the item to be found and returned'
     assert result.pk == 7, 'The item is not the correct one'
 
-    mocked_optimizer.assert_called_once_with(Item.objects, info)
+    mocked_optimizer.assert_called_once_with(SomeOtherItem.objects, info)
 
 
 @pytest.mark.django_db
 @patch('graphene_django_optimizer.types.query')
 def test_should_return_none_when_node_is_not_resolved(mocked_optimizer):
-    Item.objects.create(id=7)
+    SomeOtherItem.objects.create(id=7)
+
+    info = create_resolve_info(schema, '''
+        query {
+            someOtherItems(id: $id) {
+                id
+                foo
+                children {
+                    id
+                    foo
+                }
+            }
+        }
+    ''')
+
+    info.return_type = schema.get_type('SomeOtherItemType')
+    qs = SomeOtherItem.objects.filter(name='foo')
+    mocked_optimizer.return_value = qs
+
+    assert SomeOtherItemType.get_optimized_node(info, qs, 7) is None
+    mocked_optimizer.assert_called_once_with(qs, info)
+
+
+@patch('graphene_django_optimizer.types.query')
+def test_mutating_should_not_optimize(mocked_optimizer):
 
     info = create_resolve_info(schema, '''
         query {
@@ -51,8 +75,6 @@ def test_should_return_none_when_node_is_not_resolved(mocked_optimizer):
         }
     ''')
 
-    qs = Item.objects.filter(name='foo')
-    mocked_optimizer.return_value = qs
-
-    assert ItemType.get_optimized_node(info, qs, 7) is None
-    mocked_optimizer.assert_called_once_with(qs, info)
+    info.return_type = schema.get_type('ItemType')
+    DummyItemMutation.mutate(info, 7)
+    assert mocked_optimizer.call_count == 0

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -52,11 +52,11 @@ def test_should_return_none_when_node_is_not_resolved(mocked_optimizer):
     ''')
 
     info.return_type = schema.get_type('SomeOtherItemType')
-    qs = SomeOtherItem.objects.filter(name='foo')
+    qs = SomeOtherItem.objects
     mocked_optimizer.return_value = qs
 
-    assert SomeOtherItemType.get_optimized_node(info, qs, 7) is None
-    mocked_optimizer.assert_called_once_with(qs, info)
+    assert SomeOtherItemType.get_node(info, 8) is None
+    mocked_optimizer.assert_called_once_with(SomeOtherItem.objects, info)
 
 
 @patch('graphene_django_optimizer.types.query')

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,58 @@
+import pytest
+from mock import patch
+
+from .graphql_utils import create_resolve_info
+from .models import (
+    Item,
+)
+from .schema import schema, ItemType
+
+
+@pytest.mark.django_db
+@patch('graphene_django_optimizer.types.query', return_value=Item.objects)
+def test_should_optimize_the_single_node(mocked_optimizer):
+    Item.objects.create(id=7)
+
+    info = create_resolve_info(schema, '''
+        query ItemDetails {
+            items(id: $id) {
+                id
+                foo
+                parent {
+                    id
+                }
+            }
+        }
+    ''')
+
+    result = ItemType.get_node(info, 7)
+
+    assert result, 'Expected the item to be found and returned'
+    assert result.pk == 7, 'The item is not the correct one'
+
+    mocked_optimizer.assert_called_once_with(Item.objects, info)
+
+
+@pytest.mark.django_db
+@patch('graphene_django_optimizer.types.query')
+def test_should_return_none_when_node_is_not_resolved(mocked_optimizer):
+    Item.objects.create(id=7)
+
+    info = create_resolve_info(schema, '''
+        query {
+            items(id: $id) {
+                id
+                foo
+                children {
+                    id
+                    foo
+                }
+            }
+        }
+    ''')
+
+    qs = Item.objects.filter(name='foo')
+    mocked_optimizer.return_value = qs
+
+    assert ItemType.get_optimized_node(info, qs, 7) is None
+    mocked_optimizer.assert_called_once_with(qs, info)


### PR DESCRIPTION
## Description
Queries getting a single node weren't optimized, this change introduce a custom type to implement optimizations to these objects.

For example, this query wouldn't get optimized before those changes:
```gql
query ProductDetails($id: ID!) {
  product(id: $id) {
    description
    availability {
      available
    }
  }
}
```

### The Mutation Case
Resolvers that are not actually quering a type should not be optimized.

The info objects contains the graphene return type of the query. So we can use that to check if the info object is actually about getting the node, and whether is actually needs optimization.

A mutation will not use `get_node` so it’s seems safe to assume that we want only to optimize queries’ `get_node` but never the `get_node` of mutations or `from_global_id`, we _don’t_ want them optimized as it is not mean to be a query, it’s only mean to get an object from an id.

## Usages
### Basic
```python
class ProductType(OptimizedDjangoObjectType):
    class Meta:
        model = models.Product
```

### Advanced (Custom QuerySet)

```python
class ProductType(OptimizedDjangoObjectType):
    class Meta:
        model = models.Product

    @classmethod
    def get_node(cls, info, pk):
        if info.context:
            qs = cls._meta.model.objects.visible_to_user(info.context.user)
            return cls.maybe_optimize(info, qs, pk)
        return None
```

## Checklist
- [x] Add tests;
- [x] Update README.