### PR TITLE
Add support for object type inputs in prefetch hints

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -5,6 +5,7 @@ class Item(models.Model):
     name = models.CharField(max_length=100, blank=True)
     parent = models.ForeignKey('Item', on_delete=models.SET_NULL, null=True, related_name='children')
     item = models.ForeignKey('Item', on_delete=models.SET_NULL, null=True)
+    value = models.IntegerField(default=10)
 
     item_type = 'simple'
 


### PR DESCRIPTION
This allows to pass objects as arguments, this will parse and pass as arguments (tuple):
```python
['10', {'price': {'gte': '1000'}}]
```

This is useful for cases like this:
```gql
input PriceRangeInput {
  gte: Float
  lte: Float
}

input ProductFilterInput {
  price: PriceRangeInput
}

type Query {
  products(filter: ProductFilterInput): ProductCountableConnection
}
```

Queried with something like this:
```
query CategoryProducts($id: ID!) {
  category(id: $id) {
    products(first: 10, filter: {price: {gte: 1000}}) {
      edges {
        node {
          id
        }
      }
    }
  }
}
```
