### PR TITLE
Swap to default resolver -  Fixes #25

### DIFF
--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -4,7 +4,7 @@ from django.db.models.fields.reverse_related import ManyToOneRel
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import ForeignKey, Prefetch
 from django.db.models.constants import LOOKUP_SEP
-from graphene.types.resolver import attr_resolver
+from graphene.types.resolver import default_resolver
 from graphene_django import DjangoObjectType
 from graphene_django.fields import DjangoListField
 from graphql import ResolveInfo
@@ -266,7 +266,7 @@ class QueryOptimizer(object):
             resolver_fn = resolver
             if resolver_fn.func == DjangoListField.list_resolver:
                 resolver_fn = resolver_fn.args[0]
-            if resolver_fn.func == attr_resolver:
+            if resolver_fn.func == default_resolver:
                 return resolver_fn.args[0]
 
     def _is_resolver_for_id_field(self, resolver):


### PR DESCRIPTION
Graphene 2.1.5 changed the default resolver to attr_resolver for dict_or_attr_resolver.

See:
https://github.com/graphql-python/graphene/blob/89a352e93ab17161ae20e5994814ec8bcc8e3988/graphene/types/resolver.py 

This PR switches to import `default_resolver` which should ensure backwards and forwards compatibility.

@tfoxy We are using this library for prod code so it would be great to get this fixed and merged ASAP, currently the solution is to pin graphene to 2.1.3.

Let me know if I can do anything else to help.

Thanks!