### PR TITLE
Fix variable handling and null values

### DIFF
--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -4,6 +4,8 @@ from django.db.models.fields.reverse_related import ManyToOneRel
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import ForeignKey, Prefetch
 from django.db.models.constants import LOOKUP_SEP
+from graphene import InputObjectType
+from graphene.types.generic import GenericScalar
 from graphene.types.resolver import default_resolver
 from graphene_django import DjangoObjectType
 from graphene_django.fields import DjangoListField
@@ -15,7 +17,7 @@ from graphql.language.ast import (
     FragmentSpread,
     InlineFragment,
     Variable,
-    ObjectValue)
+)
 from graphql.type.definition import (
     GraphQLInterfaceType,
     GraphQLUnionType,
@@ -216,12 +218,10 @@ class QueryOptimizer(object):
         if isinstance(value, Variable):
             var_name = value.name.value
             value = info.variable_values.get(var_name)
-        if isinstance(value, ObjectValue):
-            value = {
-                field.name.value:
-                    self._get_value(info, field.value) for field in value.fields}
+        if isinstance(value, InputObjectType):
+            return value.__dict__
         else:
-            value = value.value
+            return GenericScalar.parse_literal(value)
         return value
 
     def _optimize_field_by_hints(self, store, selection, field_def, parent_type):

--- a/tests/graphql_utils.py
+++ b/tests/graphql_utils.py
@@ -13,7 +13,7 @@ from graphql.execution.base import (
 from graphql.pyutils.default_ordered_dict import DefaultOrderedDict
 
 
-def create_execution_context(schema, request_string):
+def create_execution_context(schema, request_string, variables=None):
     source = Source(request_string, 'GraphQL request')
     document_ast = parse(source)
     return ExecutionContext(
@@ -21,7 +21,7 @@ def create_execution_context(schema, request_string):
         document_ast,
         root_value=None,
         context_value=None,
-        variable_values=None,
+        variable_values=variables,
         operation_name=None,
         executor=None,
         middleware=None,
@@ -42,8 +42,8 @@ def get_field_asts_from_execution_context(exe_context):
     return field_asts
 
 
-def create_resolve_info(schema, request_string):
-    exe_context = create_execution_context(schema, request_string)
+def create_resolve_info(schema, request_string, variables=None):
+    exe_context = create_execution_context(schema, request_string, variables)
     parent_type = get_operation_root_type(schema, exe_context.operation)
     field_asts = get_field_asts_from_execution_context(exe_context)
 


### PR DESCRIPTION
This pull request fixes two issues:

### 1 – InputObject variables were not handled
When providing an object for an InputObject, as a variable instead of hard-coding it into the query, we would get:
```
AttributeError: 'AttributeFilterInput' object has no attribute 'value'
```

#### Query

```graphql
query($filters: AttributeFilterInput) {  # <-- the type is not handled
  ...
        availableAttributes(first: 10, filter: $filters) {
          edges {
            node {
              name
            }
          }
        }
  ...
}
```


#### Variables
```json
{
  "filters": {
    "search": "color"
  }
}
```

### 2 – Null values were not handled
When providing a null value, we would get:
```
AttributeError: 'NoneType' object has no attribute 'value'
```

#### Query

Same as above.


#### Variables
```json
{}
```
