### PR TITLE
Compatibility with graphene-django v2.6.0

### DIFF
--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -273,8 +273,9 @@ class QueryOptimizer(object):
             resolver_fn = resolver
             if resolver_fn.func == DjangoListField.list_resolver:
                 resolver_fn = resolver_fn.args[0]
-            if resolver_fn.func == default_resolver:
+            if isinstance(resolver_fn, functools.partial) and resolver_fn.func == default_resolver:
                 return resolver_fn.args[0]
+            return resolver_fn
 
     def _is_resolver_for_id_field(self, resolver):
         resolve_id = DjangoObjectType.resolve_id


### PR DESCRIPTION
Hi.

graphene-django-optimizer breaks with graphene-django v2.6.0 with the stack trace:

```
      ERROR:graphql.execution.utils:Traceback (most recent call last):
        File "/Users/dex4er/src/some-api/.venv/site-packages/promise/promise.py", line 487, in _resolve_from_executor
          executor(resolve, reject)
        File "/Users/dex4er/src/some-api/.venv/site-packages/promise/promise.py", line 754, in executor
          return resolve(f(*args, **kwargs))
        File "/Users/dex4er/src/some-api/.venv/site-packages/graphql/execution/middleware.py", line 75, in make_it_promise
          return next(*args, **kwargs)
        File "/Users/dex4er/src/some-api/some_api/schema.py", line 150, in resolve_some
          IpPoolType._meta.model.objects, info
        File "/Users/dex4er/src/some-api/.venv/site-packages/graphene_django_optimizer/query.py", line 41, in query
          return QueryOptimizer(info, **options).optimize(queryset)
        File "/Users/dex4er/src/some-api/.venv/site-packages/graphene_django_optimizer/query.py", line 58, in optimize
          info.field_asts[0],
        File "/Users/dex4er/src/some-api/.venv/site-packages/graphene_django_optimizer/query.py", line 165, in _optimize_gql_selections
          possible_type,
        File "/Users/dex4er/src/some-api/.venv/site-packages/graphene_django_optimizer/query.py", line 171, in _optimize_field
          store, model, selection, field_def)
        File "/Users/dex4er/src/some-api/.venv/site-packages/graphene_django_optimizer/query.py", line 179, in _optimize_field_by_name
          name = self._get_name_from_resolver(field_def.resolver)
        File "/Users/dex4er/src/some-api/.venv/site-packages/graphene_django_optimizer/query.py", line 276, in _get_name_from_resolver
          if resolver_fn.func == default_resolver:
      graphql.error.located_error.GraphQLLocatedError: type object 'SomeType' has no attribute 'func'
```
