### PR TITLE
made name fetching from resolver work for relay connections

### DIFF
--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -270,7 +270,7 @@ class QueryOptimizer(object):
             return 'id'
         elif isinstance(resolver, functools.partial):
             resolver_fn = resolver
-            if isinstance(resolver_fn, functools.partial) and resolver_fn.func != default_resolver:
+            if resolver_fn.func != default_resolver:
                 resolver_fn = resolver_fn.args[0]
             if isinstance(resolver_fn, functools.partial) and resolver_fn.func == default_resolver:
                 return resolver_fn.args[0]

--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -1,14 +1,13 @@
 import functools
 
-from django.db.models.fields.reverse_related import ManyToOneRel
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import ForeignKey, Prefetch
 from django.db.models.constants import LOOKUP_SEP
+from django.db.models.fields.reverse_related import ManyToOneRel
 from graphene import InputObjectType
 from graphene.types.generic import GenericScalar
 from graphene.types.resolver import default_resolver
 from graphene_django import DjangoObjectType
-from graphene_django.fields import DjangoListField
 from graphql import ResolveInfo
 from graphql.execution.base import (
     get_field_def,

--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -271,7 +271,7 @@ class QueryOptimizer(object):
             return 'id'
         elif isinstance(resolver, functools.partial):
             resolver_fn = resolver
-            if resolver_fn.func == DjangoListField.list_resolver:
+            if isinstance(resolver_fn, functools.partial) and resolver_fn.func != default_resolver:
                 resolver_fn = resolver_fn.args[0]
             if isinstance(resolver_fn, functools.partial) and resolver_fn.func == default_resolver:
                 return resolver_fn.args[0]


### PR DESCRIPTION
Hi,

I noticed there was an issue with optimizations when child relay connections are selected. This seems to be from the name not being derived from the resolver.

I've adapted the special case for DjangoListFields which seems to do the trick but may be too general.

Cheers