### PR TITLE
Add support for optimizing querysets with annotations

### DIFF
--- a/graphene_django_optimizer/__init__.py
+++ b/graphene_django_optimizer/__init__.py
@@ -1,4 +1,4 @@
 from .field import field  # noqa: F401
-from .query import query  # noqa: F401
+from .query import query, QueryOptimizer  # noqa: F401
 from .resolver import resolver_hints  # noqa: F401
 from .types import OptimizedDjangoObjectType  # noqa: F401

--- a/graphene_django_optimizer/hints.py
+++ b/graphene_django_optimizer/hints.py
@@ -17,8 +17,10 @@ class OptimizationHints(object):
         select_related=noop,
         prefetch_related=noop,
         only=noop,
+        annotate=noop,
     ):
         self.model_field = model_field
         self.prefetch_related = _normalize_hint_value(prefetch_related)
         self.select_related = _normalize_hint_value(select_related)
         self.only = _normalize_hint_value(only)
+        self.annotate = _normalize_hint_value(annotate)

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -1,5 +1,6 @@
-from django.db.models import Prefetch
 import graphene
+from django.db.models import Prefetch, Count, Value, F, CharField
+from django.db.models.functions import Concat
 from graphene import ConnectionField
 from graphene_django.fields import DjangoConnectionField
 import graphene_django_optimizer as gql_optimizer
@@ -46,6 +47,7 @@ class ItemInterface(graphene.Interface):
     item_type = graphene.String()
     father = graphene.Field('tests.schema.ItemType')
     all_children = graphene.List('tests.schema.ItemType')
+    prefetched_children = graphene.List('tests.schema.ItemType')
     children_names = graphene.String()
     aux_children_names = graphene.String()
     filtered_children = graphene.List(
@@ -56,6 +58,8 @@ class ItemInterface(graphene.Interface):
         ConnectionField('tests.schema.ItemConnection', filter_input=ItemFilterInput()),
         prefetch_related=_prefetch_children,
     )
+    children_count = graphene.Int()
+    name_with_prefix = graphene.String(prefix=graphene.String(required=True))
 
     def resolve_foo(root, info):
         return 'bar'
@@ -65,6 +69,18 @@ class ItemInterface(graphene.Interface):
     )
     def resolve_children_names(root, info):
         return ' '.join(item.name for item in root.children.all())
+
+    @gql_optimizer.resolver_hints(
+        prefetch_related=lambda info: Prefetch(
+            "children",
+            queryset=gql_optimizer.QueryOptimizer(
+                info, parent_id_field="parent_id"
+            ).optimize(Item.objects.all()),
+            to_attr="gql_prefetched_children",
+        )
+    )
+    def resolve_prefetched_children(root, info):
+        return getattr(root, 'gql_prefetched_children')
 
     @gql_optimizer.resolver_hints(
         prefetch_related='children',
@@ -84,6 +100,24 @@ class ItemInterface(graphene.Interface):
 
     def resolve_children_custom_filtered(root, info, *_args):
         return getattr(root, 'gql_custom_filtered_children')
+
+    @gql_optimizer.resolver_hints(
+        annotate={
+            'gql_children_count': Count('children')
+        }
+    )
+    def resolve_children_count(root, info):
+        return getattr(root, 'gql_children_count')
+
+    @gql_optimizer.resolver_hints(
+        annotate=lambda info, prefix: {
+            'gql_name_with_prefix': Concat(
+                Value(prefix), Value(' '), F('name'), output_field=CharField()
+            )
+        }
+    )
+    def resolve_name_with_prefix(root, info, prefix):
+        return getattr(root, 'gql_name_with_prefix')
 
 
 class BaseItemType(OptimizedDjangoObjectType):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,4 +1,5 @@
 import pytest
+from django.db.models import Count, Prefetch
 
 import graphene_django_optimizer as gql_optimizer
 
@@ -175,3 +176,48 @@ def test_should_resolve_nested_variables():
     child_edges = item_edges[0]['node']['relayAllChildren']['edges'][0]
     assert len(child_edges) == 1
     assert child_edges['node']['id'] == '8'
+
+
+# @pytest.mark.django_db
+def test_should_annotate_queries_in_relay_schema():
+    info = create_resolve_info(schema, '''
+        query {
+            relayItems {
+                edges {
+                    node {
+                        id
+                        childrenCount
+                    }
+                }
+            }
+        }
+    ''')
+    qs = Item.objects.all()
+    items = gql_optimizer.query(qs, info)
+    optimized_items = qs.only("id").annotate(gql_children_count=Count('children'))
+    assert_query_equality(items, optimized_items)
+
+
+# @pytest.mark.django_db
+def test_should_prefetch_related_when_using_annotated_select_related_in_relay_schema():
+    info = create_resolve_info(schema, '''
+        query {
+            relayItems {
+                edges {
+                    node {
+                        id
+                        parent {
+                          id
+                          childrenCount
+                        }
+                    }
+                }
+            }
+        }
+    ''')
+    qs = Item.objects.all()
+    items = gql_optimizer.query(qs, info)
+    prefetch_qs = Item.objects.only("pk").annotate(gql_children_count=Count('children'))
+    prefetch = Prefetch('parent', queryset=prefetch_qs)
+    optimized_items = qs.only("id", "parent_id").prefetch_related(prefetch)
+    assert_query_equality(items, optimized_items)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,8 @@
 import pytest
 
-from django.db.models import Prefetch
+from django.db.models import Prefetch, CharField, Value, F
+from django.db.models.functions import Concat
+
 import graphene_django_optimizer as gql_optimizer
 
 from .graphql_utils import create_resolve_info
@@ -149,3 +151,43 @@ def test_should_return_valid_result_with_prefetch_related_as_a_function():
     ''')
     assert not result.errors
     assert result.data['items'][0]['filteredChildren'][0]['id'] == '2'
+
+
+# @pytest.mark.django_db
+def test_should_optimize_with_annotate_as_a_function():
+    info = create_resolve_info(schema, '''
+        query {
+            items(name: "foo") {
+                id
+                nameWithPrefix(prefix: "The")
+            }
+        }
+    ''')
+    qs = Item.objects.filter(name='foo')
+    items = gql_optimizer.query(qs, info)
+    optimized_items = qs.only("id").annotate(gql_name_with_prefix=Concat(
+        Value('The'), Value(' '), F('name'), output_field=CharField()
+    ))
+    assert_query_equality(items, optimized_items)
+
+
+@pytest.mark.django_db
+def test_should_return_valid_result_with_annotate_as_a_function(django_assert_num_queries):
+    parent = Item.objects.create(id=1, name='foo')
+    Item.objects.create(id=2, name='bar', parent=parent)
+    Item.objects.create(id=3, name='foobar', parent=parent)
+    with django_assert_num_queries(2):
+        result = schema.execute('''
+            query {
+                items(name: "foo") {
+                    id
+                    prefetchedChildren {
+                        id
+                        nameWithPrefix(prefix: "The")
+                    }
+                }
+            }
+        ''')
+    assert not result.errors
+    assert result.data['items'][0]['prefetchedChildren'][0]['nameWithPrefix'] == 'The bar'
+    assert result.data['items'][0]['prefetchedChildren'][1]['nameWithPrefix'] == 'The foobar'


### PR DESCRIPTION
I've been using my own fork of this library for some time alongside my own fork of graphene-django and I'm ready to merge some of the changes back that I've been using in production successfully.

For this pull request I suggest annotations. 

The biggest caveat, and why annotations should be listed as an advanced feature, is that they stop working if the optimization fails for other reasons. In my projects I always have tests that use `django_assert_num_queries` and always check that the optimization hasn't failed, like: `assert "updated_at" not in connection.queries[0]["sql"]`.

Even though annotations could be easy to break, they make this library much more powerful. An example using GeoDjango features, only calculating `distance` if it's requested. Saving an extra PostGIS calculation when not needed.

```
class LocationType(DjangoObjectType):
    distance = graphene.Float(
        required=False,
        latitude=graphene.Float(required=True),
        longitude=graphene.Float(required=True),
    )
    ...
    @gql_optimizer.resolver_hints(
        annotate=lambda info, lat, lon: {
            "distance": Distance("coords", GEOSGeometry(Point(lat, lon), srid=4326))
        },
    )
    def resolve_distance(self: Location, info: ResolveInfo, **kwargs):
        if self.distance:
            return self.distance.m
        return None
```