### PR TITLE
Fix compatibility with newer django-graphene

### DIFF
--- a/dev-env-requirements.txt
+++ b/dev-env-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-graphene==2.1.3
-graphene-django==2.2.0
+graphene==2.1.8
+graphene-django==2.7.1
 pytest==4.6.3
 pytest-django==3.5.0
 pytest-cov==2.7.1

--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -271,7 +271,15 @@ class QueryOptimizer(object):
         elif isinstance(resolver, functools.partial):
             resolver_fn = resolver
             if resolver_fn.func != default_resolver:
-                resolver_fn = resolver_fn.args[0]
+                # Some resolvers have the partial function as the second
+                # argument.
+                for arg in resolver_fn.args:
+                    if isinstance(arg, (str, functools.partial)):
+                        break
+                else:
+                    # No suitable instances found, default to first arg
+                    arg = resolver_fn.args[0]
+                resolver_fn = arg
             if isinstance(resolver_fn, functools.partial) and resolver_fn.func == default_resolver:
                 return resolver_fn.args[0]
             return resolver_fn


### PR DESCRIPTION
Newer versions of `django-graphene` have resolver functions with the model class as the first argument. Make `QueryOptimizer._get_name_from_resolver()` more robust by looking for the first function argument that is either a string or another partial function.

This PR also updates the versions of `graphene` and `django-graphene` that are used for testing.