### PR TITLE
Move the OptimizedDjangoObjectType query optimization to from get_node to get_queryset

### DIFF
--- a/graphene_django_optimizer/types.py
+++ b/graphene_django_optimizer/types.py
@@ -16,7 +16,7 @@ class OptimizedDjangoObjectType(DjangoObjectType):
 
     @classmethod
     def get_queryset(cls, queryset, info):
-        queryset = super().get_queryset(queryset, info)
+        queryset = super(OptimizedDjangoObjectType, cls).get_queryset(queryset, info)
         if cls.can_optimize_resolver(info):
             queryset = query(queryset, info)
         return queryset

--- a/graphene_django_optimizer/types.py
+++ b/graphene_django_optimizer/types.py
@@ -15,29 +15,8 @@ class OptimizedDjangoObjectType(DjangoObjectType):
             and resolver_info.return_type.graphene_type is cls)
 
     @classmethod
-    def get_optimized_node(cls, info, qs, pk):
-        return query(qs, info).get(pk=pk)
-
-    @classmethod
-    def maybe_optimize(cls, info, qs, pk):
-        try:
-            if cls.can_optimize_resolver(info):
-                return cls.get_optimized_node(info, qs, pk)
-            return qs.get(pk=pk)
-        except cls._meta.model.DoesNotExist:
-            return None
-
-    @classmethod
-    def get_node(cls, info, id):
-        """
-        Bear in mind that if you are overriding this method get_node(info, pk),
-        you should always call maybe_optimize(info, qs, pk)
-        and never directly call get_optimized_node(info, qs, pk) as it would
-        result to the node being attempted to be optimized when it is not
-        supposed to actually get optimized.
-
-        :param info:
-        :param id:
-        :return:
-        """
-        return cls.maybe_optimize(info, cls._meta.model.objects, id)
+    def get_queryset(cls, queryset, info):
+        queryset = super().get_queryset(queryset, info)
+        if cls.can_optimize_resolver(info):
+            queryset = query(queryset, info)
+        return queryset

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -83,3 +83,31 @@ def test_mutating_should_not_optimize(mocked_optimizer):
     assert result
     assert result.pk == 7
     assert mocked_optimizer.call_count == 0
+
+
+@pytest.mark.django_db
+@patch('graphene_django_optimizer.types.query',
+       return_value=SomeOtherItem.objects)
+def test_should_optimize_the_queryset(mocked_optimizer):
+    SomeOtherItem.objects.create(pk=7, name='Hello')
+
+    info = create_resolve_info(schema, '''
+        query ItemDetails {
+            someOtherItems(id: $id) {
+                id
+                foo
+                parent {
+                    id
+                }
+            }
+        }
+    ''')
+
+    info.return_type = schema.get_type('SomeOtherItemType')
+    qs = SomeOtherItem.objects.filter(pk=7)
+    result = SomeOtherItemType.get_queryset(qs, info).get()
+
+    assert result, 'Expected the item to be found and returned'
+    assert result.pk == 7, 'The item is not the correct one'
+
+    mocked_optimizer.assert_called_once_with(qs, info)


### PR DESCRIPTION
 I am looking for a way to optimise queries that are using `DjangoFilterConnectionField`. 

Based on a quick investigation of `OptimizedDjangoObjectType` it looked like it ought to work if the query optimisation was moved to `get_queryset`, and since `DjangoObjectType.get_node` calls `get_queryset` it should remain compatible with `get_node` usage.

I have only looked through the code in this library superficially, so there maybe some fundamental reason that the `get_queryset` approach is flawed, but since the tests passed locally it seemed worth opening a PR for discussion if nothing more.
