### PR TITLE
Fix wrong _get_value for variables

### DIFF
--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -217,11 +217,11 @@ class QueryOptimizer(object):
         if isinstance(value, Variable):
             var_name = value.name.value
             value = info.variable_values.get(var_name)
-        if isinstance(value, InputObjectType):
+            return value
+        elif isinstance(value, InputObjectType):
             return value.__dict__
         else:
             return GenericScalar.parse_literal(value)
-        return value
 
     def _optimize_field_by_hints(self, store, selection, field_def, parent_type):
         optimization_hints = self._get_optimization_hints(field_def.resolver)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -149,3 +149,24 @@ def test_should_return_valid_result_with_prefetch_related_as_a_function():
     ''')
     assert not result.errors
     assert result.data['items'][0]['filteredChildren'][0]['id'] == '2'
+
+
+@pytest.mark.django_db
+def test_should_return_valid_result_with_prefetch_related_as_a_function_using_variable():
+    parent = Item.objects.create(id=1, name='foo')
+    Item.objects.create(id=2, name='bar', parent=parent)
+    Item.objects.create(id=3, name='foobar', parent=parent)
+    result = schema.execute('''
+        query Foo ($name: String!) {
+            items(name: "foo") {
+                id
+                foo
+                filteredChildren(name: $name) {
+                    id
+                    foo
+                }
+            }
+        }
+    ''', variables={'name': 'bar'})
+    assert not result.errors
+    assert result.data['items'][0]['filteredChildren'][0]['id'] == '2'


### PR DESCRIPTION
The new test would fail without the issue with:

```Traceback (most recent call last):
  File "/home/bellini/.virtualenvs/gdo/lib/python3.8/site-packages/graphql/execution/executor.py", line 452, in resolve_or_error
    return executor.execute(resolve_fn, source, info, **args)
  File "/home/bellini/.virtualenvs/gdo/lib/python3.8/site-packages/graphql/execution/executors/sync.py", line 16, in execute
    return fn(*args, **kwargs)
  File "/home/bellini/dev/contrib/graphene-django-optimizer/tests/schema.py", line 193, in resolve_items
    return gql_optimizer.query(Item.objects.filter(name=name), info)
  File "/home/bellini/dev/contrib/graphene-django-optimizer/graphene_django_optimizer/query.py", line 40, in query
    return QueryOptimizer(info, **options).optimize(queryset)
  File "/home/bellini/dev/contrib/graphene-django-optimizer/graphene_django_optimizer/query.py", line 55, in optimize
    store = self._optimize_gql_selections(
  File "/home/bellini/dev/contrib/graphene-django-optimizer/graphene_django_optimizer/query.py", line 159, in _optimize_gql_selections
    self._optimize_field(
  File "/home/bellini/dev/contrib/graphene-django-optimizer/graphene_django_optimizer/query.py", line 171, in _optimize_field
    optimized_by_hints = self._optimize_field_by_hints(
  File "/home/bellini/dev/contrib/graphene-django-optimizer/graphene_django_optimizer/query.py", line 247, in _optimize_field_by_hints
    optimization_hints.prefetch_related(info, *args),
  File "/home/bellini/dev/contrib/graphene-django-optimizer/tests/schema.py", line 79, in <lambda>
    to_attr='gql_filtered_children_' + name,
TypeError: can only concatenate str (not "NoneType") to str```