### PR TITLE
Add support for Graphene3 and update lint with black

### DIFF
--- a/dev-env-requirements.txt
+++ b/dev-env-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-graphene==2.1.8
-graphene-django==2.7.1
+graphene==3.0b7
+graphene-django==3.0.0b7
 pytest==4.6.3
 pytest-django==3.5.0
 pytest-cov==2.7.1

--- a/graphene_django_optimizer/field.py
+++ b/graphene_django_optimizer/field.py
@@ -1,3 +1,4 @@
+import types
 from graphene.types.field import Field
 from graphene.types.unmountedtype import UnmountedType
 
@@ -9,12 +10,12 @@ def field(field_type, *args, **kwargs):
         field_type = Field.mounted(field_type)
 
     optimization_hints = OptimizationHints(*args, **kwargs)
-    get_resolver = field_type.get_resolver
+    wrap_resolve = field_type.wrap_resolve
 
-    def get_optimized_resolver(parent_resolver):
-        resolver = get_resolver(parent_resolver)
+    def get_optimized_resolver(self, parent_resolver):
+        resolver = wrap_resolve(parent_resolver)
         resolver.optimization_hints = optimization_hints
         return resolver
 
-    field_type.get_resolver = get_optimized_resolver
+    field_type.wrap_resolve = types.MethodType(get_optimized_resolver, field_type)
     return field_type

--- a/graphene_django_optimizer/hints.py
+++ b/graphene_django_optimizer/hints.py
@@ -19,11 +19,7 @@ def _normalize_hint_value(value):
 
 class OptimizationHints(object):
     def __init__(
-        self,
-        model_field=None,
-        select_related=noop,
-        prefetch_related=noop,
-        only=noop,
+        self, model_field=None, select_related=noop, prefetch_related=noop, only=noop,
     ):
         self.model_field = _normalize_model_field(model_field)
         self.prefetch_related = _normalize_hint_value(prefetch_related)

--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -8,19 +8,19 @@ from graphene import InputObjectType
 from graphene.types.generic import GenericScalar
 from graphene.types.resolver import default_resolver
 from graphene_django import DjangoObjectType
-from graphql import ResolveInfo
-from graphql.execution.base import (
-    get_field_def,
-)
+from graphql import GraphQLResolveInfo, GraphQLSchema
+from graphql.execution.execute import get_field_def
 from graphql.language.ast import (
-    FragmentSpread,
-    InlineFragment,
-    Variable,
+    FragmentSpreadNode,
+    InlineFragmentNode,
+    VariableNode,
 )
 from graphql.type.definition import (
     GraphQLInterfaceType,
     GraphQLUnionType,
 )
+
+from graphql.pyutils import Path
 
 from .utils import is_iterable
 
@@ -31,7 +31,7 @@ def query(queryset, info, **options):
 
     Arguments:
         - queryset (Django QuerySet object) - The queryset to be optimized
-        - info (GraphQL ResolveInfo object) - This is passed by the graphene-django resolve methods
+        - info (GraphQL GraphQLResolveInfo object) - This is passed by the graphene-django resolve methods
         - **options - optimization options/settings
             - disable_abort_only (boolean) - in case the objecttype contains any extra fields,
                                              then this will keep the "only" optimization enabled.
@@ -47,29 +47,36 @@ class QueryOptimizer(object):
 
     def __init__(self, info, **options):
         self.root_info = info
-        self.disable_abort_only = options.pop('disable_abort_only', False)
+        self.disable_abort_only = options.pop("disable_abort_only", False)
 
     def optimize(self, queryset):
         info = self.root_info
         field_def = get_field_def(info.schema, info.parent_type, info.field_name)
         store = self._optimize_gql_selections(
             self._get_type(field_def),
-            info.field_asts[0],
+            info.field_nodes[0],
             # info.parent_type,
         )
         return store.optimize_queryset(queryset)
 
     def _get_type(self, field_def):
         a_type = field_def.type
-        while hasattr(a_type, 'of_type'):
+        while hasattr(a_type, "of_type"):
             a_type = a_type.of_type
         return a_type
 
+    def _get_graphql_schema(self, schema):
+        if isinstance(schema, GraphQLSchema):
+            return schema
+        else:
+            return schema.graphql_schema
+
     def _get_possible_types(self, graphql_type):
         if isinstance(graphql_type, (GraphQLInterfaceType, GraphQLUnionType)):
-            return self.root_info.schema.get_possible_types(graphql_type)
+            graphql_schema = self._get_graphql_schema(self.root_info.schema)
+            return graphql_schema.get_possible_types(graphql_type)
         else:
-            return (graphql_type, )
+            return (graphql_type,)
 
     def _get_base_model(self, graphql_types):
         models = tuple(t.graphene_type._meta.model for t in graphql_types)
@@ -80,17 +87,18 @@ class QueryOptimizer(object):
 
     def handle_inline_fragment(self, selection, schema, possible_types, store):
         fragment_type_name = selection.type_condition.name.value
-        fragment_type = schema.get_type(fragment_type_name)
+        graphql_schema = self._get_graphql_schema(schema)
+        fragment_type = graphql_schema.get_type(fragment_type_name)
         fragment_possible_types = self._get_possible_types(fragment_type)
         for fragment_possible_type in fragment_possible_types:
             fragment_model = fragment_possible_type.graphene_type._meta.model
             parent_model = self._get_base_model(possible_types)
             if not parent_model:
                 continue
-            path_from_parent = _get_path_from_parent(
-                fragment_model._meta, parent_model)
+            path_from_parent = _get_path_from_parent(fragment_model._meta, parent_model)
             select_related_name = LOOKUP_SEP.join(
-                p.join_field.name for p in path_from_parent)
+                p.join_field.name for p in path_from_parent
+            )
             if not select_related_name:
                 continue
             fragment_store = self._optimize_gql_selections(
@@ -111,24 +119,23 @@ class QueryOptimizer(object):
         store.append(fragment_store)
 
     def _optimize_gql_selections(self, field_type, field_ast):
-        store = QueryOptimizerStore(
-            disable_abort_only=self.disable_abort_only,
-        )
+        store = QueryOptimizerStore(disable_abort_only=self.disable_abort_only,)
 
         selection_set = field_ast.selection_set
         if not selection_set:
             return store
         optimized_fields_by_model = {}
         schema = self.root_info.schema
-        graphql_type = schema.get_graphql_type(field_type.graphene_type)
+        graphql_schema = self._get_graphql_schema(schema)
+        graphql_type = graphql_schema.get_type(field_type.name)
+
         possible_types = self._get_possible_types(graphql_type)
         for selection in selection_set.selections:
-            if isinstance(selection, InlineFragment):
-                self.handle_inline_fragment(
-                    selection, schema, possible_types, store)
+            if isinstance(selection, InlineFragmentNode):
+                self.handle_inline_fragment(selection, schema, possible_types, store)
             else:
                 name = selection.name.value
-                if isinstance(selection, FragmentSpread):
+                if isinstance(selection, FragmentSpreadNode):
                     self.handle_fragment_spread(store, name, field_type)
                 else:
                     for possible_type in possible_types:
@@ -138,13 +145,12 @@ class QueryOptimizer(object):
 
                         graphene_type = possible_type.graphene_type
                         # Check if graphene type is a relay connection or a relay edge
-                        if hasattr(graphene_type._meta, 'node') or (
-                            hasattr(graphene_type, 'cursor')
-                            and hasattr(graphene_type, 'node')
+                        if hasattr(graphene_type._meta, "node") or (
+                            hasattr(graphene_type, "cursor")
+                            and hasattr(graphene_type, "node")
                         ):
                             relay_store = self._optimize_gql_selections(
-                                self._get_type(selection_field_def),
-                                selection,
+                                self._get_type(selection_field_def), selection,
                             )
                             store.append(relay_store)
                             try:
@@ -152,7 +158,7 @@ class QueryOptimizer(object):
                             except ImportError:
                                 store.abort_only_optimization()
                         else:
-                            model = getattr(graphene_type._meta, 'model', None)
+                            model = getattr(graphene_type._meta, "model", None)
                             if model and name not in optimized_fields_by_model:
                                 field_model = optimized_fields_by_model[name] = model
                                 if field_model == model:
@@ -167,15 +173,17 @@ class QueryOptimizer(object):
 
     def _optimize_field(self, store, model, selection, field_def, parent_type):
         optimized_by_name = self._optimize_field_by_name(
-            store, model, selection, field_def)
+            store, model, selection, field_def
+        )
         optimized_by_hints = self._optimize_field_by_hints(
-            store, selection, field_def, parent_type)
+            store, selection, field_def, parent_type
+        )
         optimized = optimized_by_name or optimized_by_hints
         if not optimized:
             store.abort_only_optimization()
 
     def _optimize_field_by_name(self, store, model, selection, field_def):
-        name = self._get_name_from_resolver(field_def.resolver)
+        name = self._get_name_from_resolver(field_def.resolve)
         if not name:
             return False
         model_field = self._get_model_field_from_name(model, name)
@@ -211,10 +219,10 @@ class QueryOptimizer(object):
         return False
 
     def _get_optimization_hints(self, resolver):
-        return getattr(resolver, 'optimization_hints', None)
+        return getattr(resolver, "optimization_hints", None)
 
     def _get_value(self, info, value):
-        if isinstance(value, Variable):
+        if isinstance(value, VariableNode):
             var_name = value.name.value
             value = info.variable_values.get(var_name)
             return value
@@ -224,14 +232,11 @@ class QueryOptimizer(object):
             return GenericScalar.parse_literal(value)
 
     def _optimize_field_by_hints(self, store, selection, field_def, parent_type):
-        optimization_hints = self._get_optimization_hints(field_def.resolver)
+        optimization_hints = self._get_optimization_hints(field_def.resolve)
         if not optimization_hints:
             return False
         info = self._create_resolve_info(
-            selection.name.value,
-            (selection,),
-            self._get_type(field_def),
-            parent_type,
+            selection.name.value, (selection,), self._get_type(field_def), parent_type,
         )
 
         args = []
@@ -240,17 +245,14 @@ class QueryOptimizer(object):
         args = tuple(args)
 
         self._add_optimization_hints(
-            optimization_hints.select_related(info, *args),
-            store.select_list,
+            optimization_hints.select_related(info, *args), store.select_list,
         )
         self._add_optimization_hints(
-            optimization_hints.prefetch_related(info, *args),
-            store.prefetch_list,
+            optimization_hints.prefetch_related(info, *args), store.prefetch_list,
         )
         if store.only_list is not None:
             self._add_optimization_hints(
-                optimization_hints.only(info, *args),
-                store.only_list,
+                optimization_hints.only(info, *args), store.only_list,
             )
         return True
 
@@ -267,7 +269,7 @@ class QueryOptimizer(object):
             if name_fn:
                 return name_fn()
         if self._is_resolver_for_id_field(resolver):
-            return 'id'
+            return "id"
         elif isinstance(resolver, functools.partial):
             resolver_fn = resolver
             if resolver_fn.func != default_resolver:
@@ -280,16 +282,19 @@ class QueryOptimizer(object):
                     # No suitable instances found, default to first arg
                     arg = resolver_fn.args[0]
                 resolver_fn = arg
-            if isinstance(resolver_fn, functools.partial) and resolver_fn.func == default_resolver:
+            if (
+                isinstance(resolver_fn, functools.partial)
+                and resolver_fn.func == default_resolver
+            ):
                 return resolver_fn.args[0]
             if self._is_resolver_for_id_field(resolver_fn):
-                return 'id'
+                return "id"
             return resolver_fn
 
     def _is_resolver_for_id_field(self, resolver):
         resolve_id = DjangoObjectType.resolve_id
         # For python 2 unbound method:
-        if hasattr(resolve_id, 'im_func'):
+        if hasattr(resolve_id, "im_func"):
             resolve_id = resolve_id.im_func
         return resolver == resolve_id
 
@@ -300,8 +305,9 @@ class QueryOptimizer(object):
             descriptor = model.__dict__.get(name)
             if not descriptor:
                 return None
-            return getattr(descriptor, 'rel', None) \
-                or getattr(descriptor, 'related', None)  # Django < 1.9
+            return getattr(descriptor, "rel", None) or getattr(
+                descriptor, "related", None
+            )  # Django < 1.9
 
     def _is_foreign_key_id(self, model_field, name):
         return (
@@ -311,21 +317,23 @@ class QueryOptimizer(object):
         )
 
     def _create_resolve_info(self, field_name, field_asts, return_type, parent_type):
-        return ResolveInfo(
+        return GraphQLResolveInfo(
             field_name,
             field_asts,
             return_type,
             parent_type,
+            Path(None, 0, None),
             schema=self.root_info.schema,
             fragments=self.root_info.fragments,
             root_value=self.root_info.root_value,
             operation=self.root_info.operation,
             variable_values=self.root_info.variable_values,
             context=self.root_info.context,
+            is_awaitable=self.root_info.is_awaitable,
         )
 
 
-class QueryOptimizerStore():
+class QueryOptimizerStore:
     def __init__(self, disable_abort_only=False):
         self.select_list = []
         self.prefetch_list = []
@@ -402,7 +410,7 @@ def _get_path_from_parent(self, parent):
     model to the current model, or an empty list if parent is not a
     parent of the current model.
     """
-    if hasattr(self, 'get_path_from_parent'):
+    if hasattr(self, "get_path_from_parent"):
         return self.get_path_from_parent(parent)
     if self.model is parent:
         return []

--- a/graphene_django_optimizer/types.py
+++ b/graphene_django_optimizer/types.py
@@ -12,7 +12,8 @@ class OptimizedDjangoObjectType(DjangoObjectType):
     def can_optimize_resolver(cls, resolver_info):
         return (
             isinstance(resolver_info.return_type, GrapheneObjectType)
-            and resolver_info.return_type.graphene_type is cls)
+            and resolver_info.return_type.graphene_type is cls
+        )
 
     @classmethod
     def get_queryset(cls, queryset, info):

--- a/graphene_django_optimizer/utils.py
+++ b/graphene_django_optimizer/utils.py
@@ -2,4 +2,4 @@ noop = lambda *args, **kwargs: None
 
 
 def is_iterable(obj):
-    return hasattr(obj, '__iter__') and not isinstance(obj, str)
+    return hasattr(obj, "__iter__") and not isinstance(obj, str)

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import os
 import sys
 from setuptools import setup
 
-needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner >=4.0,<5dev'] if needs_pytest else []
+needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
+pytest_runner = ["pytest-runner >=4.0,<5dev"] if needs_pytest else []
 
 
 def read(fname):
@@ -13,37 +13,37 @@ def read(fname):
 
 
 setup(
-    name='graphene-django-optimizer',
-    version='0.8.0',
-    author='Tomás Fox',
-    author_email='tomas.c.fox@gmail.com',
-    description='Optimize database access inside graphene queries.',
-    license='MIT',
-    keywords='graphene django optimizer optimize graphql query prefetch select related',
-    url='https://github.com/tfoxy/graphene-django-optimizer',
-    packages=['graphene_django_optimizer'],
+    name="graphene-django-optimizer",
+    version="0.8.0",
+    author="Tomás Fox",
+    author_email="tomas.c.fox@gmail.com",
+    description="Optimize database access inside graphene queries.",
+    license="MIT",
+    keywords="graphene django optimizer optimize graphql query prefetch select related",
+    url="https://github.com/tfoxy/graphene-django-optimizer",
+    packages=["graphene_django_optimizer"],
     setup_requires=pytest_runner,
-    long_description=read('README.md'),
-    long_description_content_type='text/markdown',
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
+        "Development Status :: 4 - Beta",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Framework :: Django",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.0",
+        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3.0",
+        "Framework :: Django :: 3.1",
     ],
 )

--- a/tests/graphql_utils.py
+++ b/tests/graphql_utils.py
@@ -1,48 +1,43 @@
 from graphql import (
-    ResolveInfo,
+    GraphQLResolveInfo,
     Source,
     Undefined,
     parse,
 )
-from graphql.execution.base import (
+from graphql.execution.execute import (
     ExecutionContext,
-    collect_fields,
     get_field_def,
-    get_operation_root_type,
 )
-from graphql.pyutils.default_ordered_dict import DefaultOrderedDict
+from graphql.utilities import get_operation_root_type
+from collections import defaultdict
+
+from graphql.pyutils import Path
 
 
 def create_execution_context(schema, request_string, variables=None):
-    source = Source(request_string, 'GraphQL request')
+    source = Source(request_string, "GraphQL request")
     document_ast = parse(source)
-    return ExecutionContext(
+    return ExecutionContext.build(
         schema,
         document_ast,
         root_value=None,
         context_value=None,
-        variable_values=variables,
+        raw_variable_values=variables,
         operation_name=None,
-        executor=None,
         middleware=None,
-        allow_subscriptions=False,
     )
 
 
 def get_field_asts_from_execution_context(exe_context):
-    fields = collect_fields(
-        exe_context,
-        type,
-        exe_context.operation.selection_set,
-        DefaultOrderedDict(list),
-        set()
+    fields = exe_context.collect_fields(
+        type, exe_context.operation.selection_set, defaultdict(list), set()
     )
     # field_asts = next(iter(fields.values()))
     field_asts = tuple(fields.values())[0]
     return field_asts
 
 
-def create_resolve_info(schema, request_string, variables=None):
+def create_resolve_info(schema, request_string, variables=None, return_type=None):
     exe_context = create_execution_context(schema, request_string, variables)
     parent_type = get_operation_root_type(schema, exe_context.operation)
     field_asts = get_field_asts_from_execution_context(exe_context)
@@ -50,24 +45,26 @@ def create_resolve_info(schema, request_string, variables=None):
     field_ast = field_asts[0]
     field_name = field_ast.name.value
 
-    field_def = get_field_def(schema, parent_type, field_name)
-    if not field_def:
-        return Undefined
-    return_type = field_def.type
+    if return_type is None:
+        field_def = get_field_def(schema, parent_type, field_name)
+        if not field_def:
+            return Undefined
+        return_type = field_def.type
 
     # The resolve function's optional third argument is a context value that
     # is provided to every resolve function within an execution. It is commonly
     # used to represent an authenticated user, or request-specific caches.
-    context = exe_context.context_value
-    return ResolveInfo(
+    return GraphQLResolveInfo(
         field_name,
         field_asts,
         return_type,
         parent_type,
-        schema=schema,
-        fragments=exe_context.fragments,
-        root_value=exe_context.root_value,
-        operation=exe_context.operation,
-        variable_values=exe_context.variable_values,
-        context=context
+        Path(None, 0, None),
+        schema,
+        exe_context.fragments,
+        exe_context.root_value,
+        exe_context.operation,
+        exe_context.variable_values,
+        exe_context.context_value,
+        exe_context.is_awaitable,
     )

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,11 +3,13 @@ from django.db import models
 
 class Item(models.Model):
     name = models.CharField(max_length=100, blank=True)
-    parent = models.ForeignKey('Item', on_delete=models.SET_NULL, null=True, related_name='children')
-    item = models.ForeignKey('Item', on_delete=models.SET_NULL, null=True)
+    parent = models.ForeignKey(
+        "Item", on_delete=models.SET_NULL, null=True, related_name="children"
+    )
+    item = models.ForeignKey("Item", on_delete=models.SET_NULL, null=True)
     value = models.IntegerField(default=10)
 
-    item_type = 'simple'
+    item_type = "simple"
 
     @property
     def title(self):
@@ -32,7 +34,7 @@ class RelatedItem(Item):
 
 class RelatedOneToManyItem(models.Model):
     name = models.CharField(max_length=100, blank=True)
-    item = models.ForeignKey(Item, on_delete=models.PROTECT, related_name='otm_items')
+    item = models.ForeignKey(Item, on_delete=models.PROTECT, related_name="otm_items")
 
 
 class ExtraDetailedItem(DetailedItem):
@@ -49,4 +51,6 @@ class SomeOtherItem(models.Model):
 
 class OtherItem(models.Model):
     name = models.CharField(max_length=100, blank=True)
-    some_other_item = models.ForeignKey('SomeOtherItem', on_delete=models.PROTECT, null=False)
+    some_other_item = models.ForeignKey(
+        "SomeOtherItem", on_delete=models.PROTECT, null=False
+    )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,9 +1,5 @@
-INSTALLED_APPS = (
-    'tests',
-)
+INSTALLED_APPS = ("tests",)
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", },
 }
-SECRET_KEY = 'dummy'
+SECRET_KEY = "dummy"

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,15 +1,17 @@
+import pytest
 import graphene_django_optimizer as gql_optimizer
 
 from .graphql_utils import create_resolve_info
-from .models import (
-    Item,
-)
+from .models import Item
 from .schema import schema
 from .test_utils import assert_query_equality
 
 
+@pytest.mark.django_db
 def test_should_optimize_non_django_field_if_it_has_an_optimization_hint_in_the_field():
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "bar") {
                 id
@@ -19,23 +21,28 @@ def test_should_optimize_non_django_field_if_it_has_an_optimization_hint_in_the_
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='bar')
+    """,
+    )
+    qs = Item.objects.filter(name="bar")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.select_related('parent')
+    optimized_items = qs.select_related("parent")
     assert_query_equality(items, optimized_items)
 
 
+@pytest.mark.django_db
 def test_should_optimize_with_only_hint():
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
                 title
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.only('id', 'name')
+    optimized_items = qs.only("id", "name")
     assert_query_equality(items, optimized_items)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -15,11 +15,13 @@ from .schema import schema
 from .test_utils import assert_query_equality
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_reduce_number_of_queries_by_using_select_related():
     # parent = Item.objects.create(name='foo')
     # Item.objects.create(name='bar', parent=parent)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "bar") {
                 id
@@ -29,18 +31,21 @@ def test_should_reduce_number_of_queries_by_using_select_related():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='bar')
+    """,
+    )
+    qs = Item.objects.filter(name="bar")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.select_related('parent')
+    optimized_items = qs.select_related("parent")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_reduce_number_of_queries_by_using_prefetch_related():
     # parent = Item.objects.create(name='foo')
     # Item.objects.create(name='bar', parent=parent)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
@@ -51,103 +56,122 @@ def test_should_reduce_number_of_queries_by_using_prefetch_related():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.prefetch_related('children')
+    optimized_items = qs.prefetch_related("children")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_optimize_scalar_model_fields():
     # Item.objects.create(name='foo')
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
                 name
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.only('id', 'name')
+    optimized_items = qs.only("id", "name")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_optimize_scalar_foreign_key_model_fields():
     # parent = Item.objects.create(name='foo')
     # Item.objects.create(name='bar', parent=parent)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "bar") {
                 id
                 parentId
             }
         }
-    ''')
-    qs = Item.objects.filter(name='bar')
+    """,
+    )
+    qs = Item.objects.filter(name="bar")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.only('id', 'parent_id')
+    optimized_items = qs.only("id", "parent_id")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_not_try_to_optimize_non_model_fields():
     # Item.objects.create(name='foo')
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
                 foo
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
     optimized_items = qs
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_not_try_to_optimize_non_field_model_fields():
     # Item.objects.create(name='foo')
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
                 unoptimizedTitle
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
     optimized_items = qs
     assert_query_equality(items, optimized_items)
 
 
+@pytest.mark.django_db
 def test_should_try_to_optimize_non_field_model_fields_when_disabling_abort_only():
     # Item.objects.create(name='foo')
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
                 unoptimizedTitle
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info, disable_abort_only=True)
-    optimized_items = qs.only('id')
+    optimized_items = qs.only("id")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_optimize_when_using_fragments():
     # parent = Item.objects.create(name='foo')
     # Item.objects.create(name='bar', parent=parent)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "bar") {
                 ...ItemFragment
@@ -159,18 +183,21 @@ def test_should_optimize_when_using_fragments():
                 id
             }
         }
-    ''')
-    qs = Item.objects.filter(name='bar')
+    """,
+    )
+    qs = Item.objects.filter(name="bar")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.select_related('parent').only('id', 'parent__id')
+    optimized_items = qs.select_related("parent").only("id", "parent__id")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_prefetch_field_with_camel_case_name():
     # item = Item.objects.create(name='foo')
     # Item.objects.create(name='bar', item=item)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
@@ -181,19 +208,22 @@ def test_should_prefetch_field_with_camel_case_name():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.prefetch_related('item_set')
+    optimized_items = qs.prefetch_related("item_set")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_select_nested_related_fields():
     # parent = Item.objects.create(name='foo')
     # parent = Item.objects.create(name='bar', parent=parent)
     # Item.objects.create(name='foobar', parent=parent)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foobar") {
                 id
@@ -206,19 +236,22 @@ def test_should_select_nested_related_fields():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foobar')
+    """,
+    )
+    qs = Item.objects.filter(name="foobar")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.select_related('parent__parent')
+    optimized_items = qs.select_related("parent__parent")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_prefetch_nested_related_fields():
     # parent = Item.objects.create(name='foo')
     # parent = Item.objects.create(name='bar', parent=parent)
     # Item.objects.create(name='foobar', parent=parent)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
@@ -233,19 +266,22 @@ def test_should_prefetch_nested_related_fields():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.prefetch_related('children__children')
+    optimized_items = qs.prefetch_related("children__children")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_prefetch_nested_select_related_field():
     # parent = Item.objects.create(name='foo')
     # item = Item.objects.create(name='foobar')
     # Item.objects.create(name='bar', parent=parent, item=item)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
@@ -259,21 +295,24 @@ def test_should_prefetch_nested_select_related_field():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
     optimized_items = qs.prefetch_related(
-        Prefetch('children', queryset=Item.objects.select_related('item')),
+        Prefetch("children", queryset=Item.objects.select_related("item")),
     )
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_select_nested_prefetch_related_field():
     # parent = Item.objects.create(name='foo')
     # Item.objects.create(name='bar', parent=parent)
     # Item.objects.create(name='foobar', item=parent)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foobar") {
                 id
@@ -287,20 +326,23 @@ def test_should_select_nested_prefetch_related_field():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foobar')
+    """,
+    )
+    qs = Item.objects.filter(name="foobar")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.select_related('item').prefetch_related('item__children')
+    optimized_items = qs.select_related("item").prefetch_related("item__children")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_select_nested_prefetch_and_select_related_fields():
     # parent = Item.objects.create(name='foo')
     # item = Item.objects.create(name='bar_item')
     # Item.objects.create(name='bar', parent=parent, item=item)
     # Item.objects.create(name='foobar', item=parent)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foobar") {
                 id
@@ -317,20 +359,23 @@ def test_should_select_nested_prefetch_and_select_related_fields():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foobar')
+    """,
+    )
+    qs = Item.objects.filter(name="foobar")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.select_related('item').prefetch_related(
-        Prefetch('item__children', queryset=Item.objects.select_related('item')),
+    optimized_items = qs.select_related("item").prefetch_related(
+        Prefetch("item__children", queryset=Item.objects.select_related("item")),
     )
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_fetch_fields_of_related_field():
     # parent = Item.objects.create(name='foo')
     # Item.objects.create(name='bar', parent=parent)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "bar") {
                 id
@@ -339,18 +384,21 @@ def test_should_fetch_fields_of_related_field():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='bar')
+    """,
+    )
+    qs = Item.objects.filter(name="bar")
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.select_related('parent').only('id', 'parent__id')
+    optimized_items = qs.select_related("parent").only("id", "parent__id")
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_fetch_fields_of_prefetched_field():
     # parent = Item.objects.create(name='foo')
     # Item.objects.create(name='bar', parent=parent)
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
@@ -360,20 +408,23 @@ def test_should_fetch_fields_of_prefetched_field():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
     optimized_items = qs.prefetch_related(
-        Prefetch('children', queryset=Item.objects.only('id', 'parent__id')),
+        Prefetch("children", queryset=Item.objects.only("id", "parent__id")),
     )
     assert_query_equality(items, optimized_items)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_fetch_child_model_field_for_interface_field():
     # Item.objects.create(name='foo')
     # ExtraDetailedItem.objects.create(name='foo', extra_detail='test')
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
@@ -382,42 +433,45 @@ def test_should_fetch_child_model_field_for_interface_field():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
-    optimized_items = (
-        qs
-        .select_related('detaileditem__extradetaileditem')
-        .only('id', 'detaileditem__extradetaileditem__extra_detail')
+    optimized_items = qs.select_related("detaileditem__extradetaileditem").only(
+        "id", "detaileditem__extradetaileditem__extra_detail"
     )
     assert_query_equality(items, optimized_items)
 
 
-@pytest.mark.skip(reason='will be tested in the future')
-# @pytest.mark.django_db
+@pytest.mark.skip(reason="will be tested in the future")
+@pytest.mark.django_db
 def test_should_fetch_field_of_child_model_when_parent_has_no_optimized_field():
     # Item.objects.create(name='foo')
     # DetailedItem.objects.create(name='foo', item_type='test')
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
                 item_type
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
-    optimized_items = (
-        qs
-        .select_related('detaileditem')
-        .only('id', 'detaileditem__item_type')
+    optimized_items = qs.select_related("detaileditem").only(
+        "id", "detaileditem__item_type"
     )
     assert_query_equality(items, optimized_items)
 
 
+@pytest.mark.django_db
 def test_should_fetch_field_inside_interface_fragment():
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 id
@@ -426,19 +480,21 @@ def test_should_fetch_field_inside_interface_fragment():
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
-    optimized_items = (
-        qs
-        .select_related('detaileditem')
-        .only('id', 'detaileditem__detail')
+    optimized_items = qs.select_related("detaileditem").only(
+        "id", "detaileditem__detail"
     )
     assert_query_equality(items, optimized_items)
 
 
+@pytest.mark.django_db
 def test_should_use_nested_prefetch_related_while_also_selecting_only_required_fields():
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(name: "foo") {
                 children {
@@ -448,17 +504,15 @@ def test_should_use_nested_prefetch_related_while_also_selecting_only_required_f
                 }
             }
         }
-    ''')
-    qs = Item.objects.filter(name='foo')
+    """,
+    )
+    qs = Item.objects.filter(name="foo")
     items = gql_optimizer.query(qs, info)
     optimized_items = qs.prefetch_related(
         Prefetch(
-            'children',
-            queryset=Item.objects.only('id', 'parent_id').prefetch_related(
-                Prefetch(
-                    'children',
-                    queryset=Item.objects.only('id', 'parent_id'),
-                )
+            "children",
+            queryset=Item.objects.only("id", "parent_id").prefetch_related(
+                Prefetch("children", queryset=Item.objects.only("id", "parent_id"),)
             ),
         ),
     )
@@ -467,7 +521,9 @@ def test_should_use_nested_prefetch_related_while_also_selecting_only_required_f
 
 @pytest.mark.django_db
 def test_should_check_reverse_relations_add_foreign_key():
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items {
                 otmItems {
@@ -475,22 +531,24 @@ def test_should_check_reverse_relations_add_foreign_key():
                 }
             }
         }
-    ''')
+    """,
+    )
     qs = Item.objects.all()
     items = gql_optimizer.query(qs, info)
     optimized_items = qs.prefetch_related(
         Prefetch(
-            'otm_items',
-            queryset=RelatedOneToManyItem.objects.only('id', 'item_id'),
+            "otm_items", queryset=RelatedOneToManyItem.objects.only("id", "item_id"),
         ),
     )
     assert_query_equality(items, optimized_items)
 
     # When the query is not optimized, there will be an additional queries
     for i in range(3):
-        the_item = Item.objects.create(name='foo')
+        the_item = Item.objects.create(name="foo")
         for k in range(3):
-            RelatedOneToManyItem.objects.create(name='bar{}{}'.format(i, k), item=the_item)
+            RelatedOneToManyItem.objects.create(
+                name="bar{}{}".format(i, k), item=the_item
+            )
 
     with CaptureQueriesContext(connection) as expected_query_capture:
         for i in items:
@@ -506,17 +564,20 @@ def test_should_check_reverse_relations_add_foreign_key():
     assert len(expected_query_capture) == len(optimized_query_capture)
 
 
-# @pytest.mark.django_db
+@pytest.mark.django_db
 def test_should_only_use_the_only_and_not_select_related():
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             otherItems {
                 id
                 name
             }
         }
-    ''')
+    """,
+    )
     qs = OtherItem.objects.all()
     items = gql_optimizer.query(qs, info)
-    optimized_items = qs.only('id', 'name')
+    optimized_items = qs.only("id", "name")
     assert_query_equality(items, optimized_items)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -8,12 +8,13 @@ from .schema import schema, SomeOtherItemType, DummyItemMutation
 
 
 @pytest.mark.django_db
-@patch('graphene_django_optimizer.types.query',
-       return_value=SomeOtherItem.objects)
+@patch("graphene_django_optimizer.types.query", return_value=SomeOtherItem.objects)
 def test_should_optimize_the_single_node(mocked_optimizer):
-    SomeOtherItem.objects.create(pk=7, name='Hello')
+    SomeOtherItem.objects.create(pk=7, name="Hello")
 
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query ItemDetails {
             someOtherItems(id: $id) {
                 id
@@ -23,23 +24,26 @@ def test_should_optimize_the_single_node(mocked_optimizer):
                 }
             }
         }
-    ''')
+    """,
+        return_type=schema.graphql_schema.get_type("SomeOtherItemType"),
+    )
 
-    info.return_type = schema.get_type('SomeOtherItemType')
     result = SomeOtherItemType.get_node(info, 7)
 
-    assert result, 'Expected the item to be found and returned'
-    assert result.pk == 7, 'The item is not the correct one'
+    assert result, "Expected the item to be found and returned"
+    assert result.pk == 7, "The item is not the correct one"
 
     mocked_optimizer.assert_called_once_with(SomeOtherItem.objects, info)
 
 
 @pytest.mark.django_db
-@patch('graphene_django_optimizer.types.query')
+@patch("graphene_django_optimizer.types.query")
 def test_should_return_none_when_node_is_not_resolved(mocked_optimizer):
     SomeOtherItem.objects.create(id=7)
 
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             someOtherItems(id: $id) {
                 id
@@ -50,9 +54,10 @@ def test_should_return_none_when_node_is_not_resolved(mocked_optimizer):
                 }
             }
         }
-    ''')
+    """,
+        return_type=schema.graphql_schema.get_type("SomeOtherItemType"),
+    )
 
-    info.return_type = schema.get_type('SomeOtherItemType')
     qs = SomeOtherItem.objects
     mocked_optimizer.return_value = qs
 
@@ -61,11 +66,13 @@ def test_should_return_none_when_node_is_not_resolved(mocked_optimizer):
 
 
 @pytest.mark.django_db
-@patch('graphene_django_optimizer.types.query')
+@patch("graphene_django_optimizer.types.query")
 def test_mutating_should_not_optimize(mocked_optimizer):
     Item.objects.create(id=7)
 
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query {
             items(id: $id) {
                 id
@@ -76,22 +83,24 @@ def test_mutating_should_not_optimize(mocked_optimizer):
                 }
             }
         }
-    ''')
+    """,
+        return_type=schema.graphql_schema.get_type("SomeOtherItemType"),
+    )
 
-    info.return_type = schema.get_type('SomeOtherItemType')
-    result = DummyItemMutation.mutate(info, to_global_id('ItemNode', 7))
+    result = DummyItemMutation.mutate(info, to_global_id("ItemNode", 7))
     assert result
     assert result.pk == 7
     assert mocked_optimizer.call_count == 0
 
 
 @pytest.mark.django_db
-@patch('graphene_django_optimizer.types.query',
-       return_value=SomeOtherItem.objects)
+@patch("graphene_django_optimizer.types.query", return_value=SomeOtherItem.objects)
 def test_should_optimize_the_queryset(mocked_optimizer):
-    SomeOtherItem.objects.create(pk=7, name='Hello')
+    SomeOtherItem.objects.create(pk=7, name="Hello")
 
-    info = create_resolve_info(schema, '''
+    info = create_resolve_info(
+        schema,
+        """
         query ItemDetails {
             someOtherItems(id: $id) {
                 id
@@ -101,13 +110,14 @@ def test_should_optimize_the_queryset(mocked_optimizer):
                 }
             }
         }
-    ''')
+    """,
+        return_type=schema.graphql_schema.get_type("SomeOtherItemType"),
+    )
 
-    info.return_type = schema.get_type('SomeOtherItemType')
     qs = SomeOtherItem.objects.filter(pk=7)
     result = SomeOtherItemType.get_queryset(qs, info).get()
 
-    assert result, 'Expected the item to be found and returned'
-    assert result.pk == 7, 'The item is not the correct one'
+    assert result, "Expected the item to be found and returned"
+    assert result.pk == 7, "The item is not the correct one"
 
     mocked_optimizer.assert_called_once_with(qs, info)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,9 @@ from django.db.models import Prefetch
 
 def assert_query_equality(left_query, right_query):
     assert str(left_query.query) == str(right_query.query)
-    assert len(left_query._prefetch_related_lookups) == len(right_query._prefetch_related_lookups)
+    assert len(left_query._prefetch_related_lookups) == len(
+        right_query._prefetch_related_lookups
+    )
     for (i, lookup) in enumerate(left_query._prefetch_related_lookups):
         right_lookup = right_query._prefetch_related_lookups[i]
         if isinstance(lookup, Prefetch) and isinstance(right_lookup, Prefetch):


### PR DESCRIPTION
This PR address issue #53 

I added support for graphene and graphene-django v3. I also used black to improve the formatting of the code.

However with this change it looks like the only versions of Django supported are > 3

All the test pass. Please let me know if we can merge it or you need more info. 