### PR TITLE
WIP: Update dependencies for non-beta graphene-django v3 release

### DIFF
--- a/dev-env-requirements.txt
+++ b/dev-env-requirements.txt
@@ -1,9 +1,10 @@
 -r requirements.txt
-graphene==3.0b7
-graphene-django==3.0.0b7
+graphene~=3.0.0
+graphene-django==3.0.0
 pytest==4.6.3
 pytest-django==3.5.0
 pytest-cov==2.7.1
 flake8==3.7.7
 mock==2.0.0
 black==21.6b0
+graphql-core~=3.1.7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,2 @@
 -r dev-env-requirements.txt
-django==3.1.13
+django==3.2.16


### PR DESCRIPTION
`graphene-django` released a non-beta version of v3 in Sept 2022 (https://github.com/graphql-python/graphene-django/releases/tag/v3.0.0).

This updates the dev dependencies accordingly, to no longer point to the beta releases. 

This PR is meant as demonstration only, since in its current form, `graphene-django-optimizer` unfortunately actually does **not** properly SQL-optimize nested fields (among other things), when used with the latest version of `graphene-django`. This can be seen in that several tests related to SQL optimization now fail after this version upgrade, such as `test_should_select_nested_prefetch_and_select_related_fields`.