### PR TITLE
Pass field_node instead of field_name

### DIFF
--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -51,7 +51,7 @@ class QueryOptimizer(object):
 
     def optimize(self, queryset):
         info = self.root_info
-        field_def = get_field_def(info.schema, info.parent_type, info.field_name)
+        field_def = get_field_def(info.schema, info.parent_type, info.field_nodes[0])
         store = self._optimize_gql_selections(
             self._get_type(field_def),
             info.field_nodes[0],


### PR DESCRIPTION
graphene has changed the signature of get_field_def to receive `field_node: FieldNode` instead of `field_name`